### PR TITLE
get rid of basic settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,6 @@ and bake your new QA package providing some information::
 
     $ pip install cookiecutter
     $ cookiecutter https://github.com/tierratelematics/cookiecutter-qa
-    advanced [y]:
     full_name [Davide Moro]: 
     email [davide.moro@gmail.com]: 
     github_username [tierratelematics]: 
@@ -56,33 +55,11 @@ and bake your new QA package providing some information::
     testrail [y]:
     $ cd project_qa
 
-As result cookiecutter will create for you a new package.
+As result cookiecutter will create for you a new package with a hello world test pytest_, Splinter_, BDD and page
+objects ready.
 
 **Important note**: be aware that the Browserstack access key will be saved in ``project_name/Dockerfile``
 so keep in mind that before distributing your project!
-
-
-Advanced (y)
-------------
-
-If you respond ``advanced: y`` you get an opinionated stack with a hello world test pytest_, Splinter_, BDD and page objects ready.
-
-
-Advanced (n)
-------------
-If you respond ``advanced: n`` you get a basic project with a basic hello world based on Selenium Splinter.
-
-You can see the ``test_basic.py`` contents::
-
-    $ cat project_qa/project_qa/tests/functional/test_basic.py 
-    
-    
-    def test_basic(browser, base_url):
-        browser.visit(base_url)
-        assert 'http://www.tierratelematics.com' in browser.url
-
-This is what you need if you want to familiarize with pytest_, Splinter_ API or if you want create your own setup
-that fits your needs.
 
 
 How to use it

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,4 @@
 {
-  "advanced": "y",
   "full_name": "Davide Moro",
   "email": "davide.moro@gmail.com",
   "github_username": "tierratelematics",

--- a/docs/prompts.rst
+++ b/docs/prompts.rst
@@ -8,9 +8,6 @@ Templated Values
 
 The following appear in various parts of your generated project.
 
-advanced
-    ``n`` if you want a very simple hello world test, ``y`` for an opinionated setup with BDD, page objects
-
 full_name
     Your full name.
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -26,15 +26,3 @@ if __name__ == '__main__':
 
     if '{{ cookiecutter.testrail }}' == 'n':
         remove_file('testrail.cfg')
-
-    if '{{ cookiecutter.advanced }}' == 'n':
-        remove_folder('{{cookiecutter.project_slug}}', 'pages')
-        remove_folder('{{cookiecutter.project_slug}}', 'features')
-        remove_file('{{cookiecutter.project_slug}}', 'config.py')
-        remove_file('{{cookiecutter.project_slug}}', 'cli.py')
-        remove_file('{{cookiecutter.project_slug}}', 'tests',
-                    'functional', 'test_login.py')
-        remove_file('{{cookiecutter.project_slug}}', 'tests',
-                    'functional', 'test_logout.py')
-        remove_file('{{cookiecutter.project_slug}}', 'tests',
-                    'functional', 'conftest.py')

--- a/tests/test_bake_project.py
+++ b/tests/test_bake_project.py
@@ -162,42 +162,6 @@ def test_bake_and_run_tests(cookies, default_extra_context):
         print("test_bake_and_run_tests path", str(result.project))
 
 
-def test_bake_withspecialchars_and_run_tests(cookies, default_extra_context):
-    """Ensure that a `full_name` with double quotes does not break setup.py"""
-    extra_context = default_extra_context.copy()
-    extra_context['full_name'] = 'name "quote" name'
-    with bake_in_temp_dir(cookies, extra_context=extra_context) as result:
-        assert result.project.isdir()
-        run_inside_dir(
-            'make docker-run BROWSERSTACK_ACCESS_KEY={0}'.format(
-                default_extra_context['browserstack_access_key']),
-            str(result.project)) == 0
-
-
-def test_bake_with_apostrophe_and_run_tests(cookies, default_extra_context):
-    """Ensure that a `full_name` with apostrophes does not break setup.py"""
-    extra_context = default_extra_context.copy()
-    extra_context['full_name'] = "O'connor"
-    with bake_in_temp_dir(cookies, extra_context=extra_context) as result:
-        assert result.project.isdir()
-        run_inside_dir(
-            'make docker-run BROWSERSTACK_ACCESS_KEY={0}'.format(
-                default_extra_context['browserstack_access_key']),
-            str(result.project)) == 0
-
-
-def test_bake_with_basic_and_run_tests(cookies, default_extra_context):
-    """Ensure that an advanced n doesn't break things"""
-    extra_context = default_extra_context.copy()
-    extra_context['advanced'] = "n"
-    with bake_in_temp_dir(cookies, extra_context=extra_context) as result:
-        assert result.project.isdir()
-        run_inside_dir(
-            'make docker-run BROWSERSTACK_ACCESS_KEY={0}'.format(
-                default_extra_context['browserstack_access_key']),
-            str(result.project)) == 0
-
-
 def test_bake_with_no_testrail_and_run_tests(cookies, default_extra_context):
     """Ensure that an without testrail doesn't break things"""
     extra_context = default_extra_context.copy()

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -4,16 +4,12 @@ version = '{{ cookiecutter.version }}dev'
 
 
 install_requires = [
-{%- if cookiecutter.advanced  == 'y' %}
     'pytest-pypom-navigation',
     'colander',
     'pytest-variables[yaml]',
     'pytest-bdd',
     'pytest-splinter',
     'pypom_form',
-{% else %}
-    'pytest-selenium',
-{%- endif %}
 {%- if cookiecutter.testrail == 'y' %}
     'pytest-testrail',
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/tests/conftest.py
@@ -1,4 +1,3 @@
-{%- if cookiecutter.advanced  == 'y' %}
 """
 Fixture Diagrams
 ----------------
@@ -99,16 +98,6 @@ def page_mappings():
         :rtype: dict`
     """
     return {{cookiecutter.project_slug}}.config.PAGE_MAPPINGS
-{%- else %}
-import os
-import pytest
-import {{cookiecutter.project_slug}}
-
-
-@pytest.fixture(scope='session')
-def base_url():
-    return "{{cookiecutter.base_url}}"
-{%- endif %}
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Get rid or basic settings, cookiecutter-qa is an opinionated testing stack that matches the Tierra needs.
Probably would be better creating a new package with a very basic setup instead of manage so different resulting packages with an advanced y/n option.

This PR removes totally the advanced y/n option and cookiecutter-qa will create always a full package