### PR TITLE
enable pytest-repeat

### DIFF
--- a/{{cookiecutter.project_slug}}/Jenkinsfile
+++ b/{{cookiecutter.project_slug}}/Jenkinsfile
@@ -12,7 +12,8 @@ properties([parameters([ \
     booleanParam(defaultValue: false, description: 'Enable debug (it might slow down test executions)', name: 'DEBUG'), \
     booleanParam(defaultValue: false, description: 'Block on first failure', name: 'BLOCK_FIRST_FAILURE'), \
     string(defaultValue: '', description: 'Number of parallel executions. Leave empty if want a sequential test execution or set the desired number of parallelism (eg: 2)', name: 'PARALLEL_SESSIONS'), \
-    string(defaultValue: '', description: 'You can specify an alternative selenium grid url', name: 'SELENIUM_GRID_URL') \
+    string(defaultValue: '', description: 'You can specify an alternative selenium grid url', name: 'SELENIUM_GRID_URL'), \
+    string(defaultValue: '', description: 'Number of test repetitions (for evaluating test robustness or random bugs until it fails)', name: 'COUNT') \
 ]), pipelineTriggers([])])
 
 
@@ -37,6 +38,7 @@ node('tox-py36') {
             env.TESTRAIL_ENABLE = params.TESTRAIL_ENABLE
             env.BLOCK_FIRST_FAILURE = params.BLOCK_FIRST_FAILURE
             env.SELENIUM_GRID_URL = params.SELENIUM_GRID_URL
+            env.COUNT = params.COUNT
 
             sh "./ci.py"
         }

--- a/{{cookiecutter.project_slug}}/ci.py
+++ b/{{cookiecutter.project_slug}}/ci.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
     os_version = os.getenv('OS')
     browser = os.getenv('BROWSER')
     parallel_sessions = os.getenv('PARALLEL_SESSIONS')
+    count = os.getenv('COUNT')
     junit_output = 'results/{0}.xml'.format(os.getenv('BUILD_ID'))
     grid_url = os.getenv('SELENIUM_GRID_URL', '')
     fallback_grid_url = '{{cookiecutter.selenium_grid_url}}'
@@ -97,6 +98,12 @@ if __name__ == "__main__":
         pytest_cmd.extend([
             "-n",
             parallel_sessions,
+        ])
+
+    if count and count > 0:
+        pytest_cmd.extend([
+            "--count",
+            count,
         ])
 
     pytest_cmd.extend(sys.argv[1:])

--- a/{{cookiecutter.project_slug}}/requirements.txt
+++ b/{{cookiecutter.project_slug}}/requirements.txt
@@ -31,6 +31,7 @@ pytest-bdd==2.19.0
 pytest-cov==2.5.1
 pytest-html==1.16.0
 pytest-metadata==1.5.0
+pytest-repeat==0.4.1
 pytest-splinter==1.8.5
 pytest-testrail==1.0.1
 pytest-travis-fold==1.2.0

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -24,6 +24,7 @@ tests_require = [
     'tox',
     'mock',
     'pytest-html',
+    'pytest-repeat',
 ]
 
 docs_require = [


### PR DESCRIPTION
enables pytest-repeat's --count option that let you repeat a given test or group of tests for a given amount of times or blocks until it fails