### PR TITLE
remove coverage default options from pytest

### DIFF
--- a/{{cookiecutter.project_slug}}/.coveragerc
+++ b/{{cookiecutter.project_slug}}/.coveragerc
@@ -1,4 +1,0 @@
-[run]
-omit =
-  *test*py
-  {{cookiecutter.project_slug}}/pages*

--- a/{{cookiecutter.project_slug}}/pytest.ini
+++ b/{{cookiecutter.project_slug}}/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -s --doctest-modules --doctest-glob='*.txt' --strict --cov=./ --cov-report=term-missing --log-cli-level=INFO {{cookiecutter.project_slug}}
+addopts = -s --doctest-modules --doctest-glob='*.txt' --strict --log-cli-level=INFO {{cookiecutter.project_slug}}
 log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 python_files = test*py


### PR DESCRIPTION
with cookiecutter-qa it doesn't make sense a local coverage because you are going to test external systems